### PR TITLE
Improve contrast for result card in dark theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ body.dark-mode {
 
 body.dark-mode .desk { background-color: #1a1a1a; }
 body.dark-mode .paper-sheet { background-color: #252525; color: #d1d1d1; border-color: #444; }
-body.dark-mode .sticky-note { background: #332f1a; color: #eee; border-color: #444; }
+body.dark-mode .sticky-note { background: #FFEF5F; color: #eee; border-color: #444; }
 body.dark-mode .word { color: #888; }
 body.dark-mode .letter.correct { color: #fff; }
 


### PR DESCRIPTION
## Related Issue
Fixes #16

## Changes
- Improved result card contrast for better readability in dark theme
- Updated styles in `style.css`

## Checklist
- [x] Code works as expected
- [x] No unnecessary changes
-
## Screenshots
<img width="1885" height="900" alt="image" src="https://github.com/user-attachments/assets/1895ed99-c91e-4b47-a099-6df0f41b81b5" />
