### PR TITLE
Fix: prevent initGame on laguage change outside game view

### DIFF
--- a/script.js
+++ b/script.js
@@ -1266,10 +1266,10 @@ document.querySelectorAll('[data-lang]').forEach(btn => {
         btn.classList.add('active');
 
         applyTranslations();
-        if (typeof initGame === 'function') {
-            initGame(false, currentView !== 'game');
+        if(currentView === 'game' && typeof initGame === 'function'){
+            initGame(false, false);
         }
-        if (currentView === 'stats') {
+        if(currentView === 'stats'){
             renderGlobalStatsTable();
         }
     });


### PR DESCRIPTION
Fixes #33 

Changing language in Settings and Stats was triggering initGame(),
causing unnecessary DOM reflow and visual movement.

This PR guards initGame so it only runs when currentView === "game",
while other views update text via applyTranslations().

