### PR TITLE
Fixed the issue of test restart on result screen in js/game.js file

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -623,8 +623,11 @@ export function finishGame() {
 export function restartGame() {
     restartBtn.addEventListener('click', initGame);
     restartBtn.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (e.key === 'Enter') {
             initGame();
+        }
+        if (e.key === ' ') {
+            return;
         }
     });
 }


### PR DESCRIPTION
### Fix: Prevent SPACE key from restarting test on results screen

#### Issue
Currently, pressing the **SPACE** key on the results screen restarts the test, which can cause accidental restarts.

#### What was changed
- Disabled the SPACE key handler on the results screen
- Ensured the test only restarts through intended user actions (e.g. Enter button)
- Prevented accidental test restarts after completion

#### Why this change
This improves user experience by avoiding unintended test restarts when users press SPACE to scroll or interact with the page after seeing results.

#### Code image
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/236c6351-6d74-4c13-8025-668d51165cc4" />

#### Related Issue
Closes #46