### PR TITLE
Remove pointer interception from header

### DIFF
--- a/styles/navbar.css
+++ b/styles/navbar.css
@@ -82,6 +82,7 @@
   margin-right: 20px;
   line-height: 1;
   position: relative;
+  pointer-events: auto;
 }
 
 .theme-toggle-btn:hover {


### PR DESCRIPTION
## Related issue
Fixes #34 

## Changes
- Add `pointer-events: none` to `.header` to prevent click interception on Settings/Stats panels
- Add `pointer-events: auto` to `.logo` to keep logo link clickable
- Add `pointer-events: auto` to `.nav-links` to keep navigation links clickable
- Add `pointer-events: auto` to `.theme-toggle-btn` to keep theme toggle button clickable

## Checklist
-  Code works as expected
-  No unnecessary changes
- Navbar buttons still functional
- Settings/Stats panel buttons now clickable
- No CSS styling changes (appearance unchanged)
